### PR TITLE
Job Details for Cancelled Jobs Bugfix

### DIFF
--- a/src/main/java/de/hsba/bi/fahrradkurier/web/job/JobIndexController.java
+++ b/src/main/java/de/hsba/bi/fahrradkurier/web/job/JobIndexController.java
@@ -31,7 +31,7 @@ public class JobIndexController {
     @GetMapping("/{jobId}")
     public String showJob(@PathVariable("jobId") Long id, Model model) {
         JobEntity jobEntity = jobService.findJobById(id);
-        if (jobEntity.getStatus().equals(JobStatusEnum.NEW)) {
+        if (jobEntity.getStatus().equals(JobStatusEnum.NEW) || jobEntity.getStatus().equals(JobStatusEnum.CANCELLED)) {
             if (userService.findCurrentUser().getRole().equals(UserRoleEnum.CUSTOMER)) {
                 userService.checkIfUserAllowed(jobEntity, false, true);
             }


### PR DESCRIPTION
When cancelling job and then viewing details, and unexpected error occured, due to the conditional in the controller. 
Extends conditional to also include cancelled jobs, allowing customers to view job details after it was cancelled.